### PR TITLE
Bugfixes

### DIFF
--- a/src/Factory/DoctrineFilesystemFactory.php
+++ b/src/Factory/DoctrineFilesystemFactory.php
@@ -25,7 +25,7 @@ class DoctrineFilesystemFactory extends AbstractDoctrineAdapterFactory
      */
     public function getAdapter(array $config)
     {
-        $client = new FilesystemCache($config['directory'], $config['extension'], $config['umask']);
+        $client = new FilesystemCache($config['directory'], $config['extension'], (int) $config['umask']);
 
         return new DoctrineCachePool($client);
     }

--- a/src/Factory/RedisFactory.php
+++ b/src/Factory/RedisFactory.php
@@ -29,7 +29,7 @@ class RedisFactory extends AbstractAdapterFactory
     public function getAdapter(array $config)
     {
         $client = new \Redis();
-        $client->client($config['host'], $config['port']);
+        $client->connect($config['host'], $config['port']);
 
         return new RedisCachePool($client);
     }


### PR DESCRIPTION
I allows `umask` to be configured as a string because I believe there might be something wrong when you try to use `0002` as an integer in the yaml. 
