### PR TITLE
Added option redundant_servers

### DIFF
--- a/src/Factory/MemcacheFactory.php
+++ b/src/Factory/MemcacheFactory.php
@@ -32,6 +32,17 @@ class MemcacheFactory extends AbstractAdapterFactory
         $client = new Memcache();
         $client->connect($config['host'], $config['port']);
 
+        foreach ($config['redundant_servers'] as $server) {
+            if (!isset($server['host'])) {
+                continue;
+            }
+            $port = $config['port'];
+            if (isset($server['port'])) {
+                $port = $server['port'];
+            }
+            $client->addserver($server['host'], $port);
+        }
+
         return new MemcacheCachePool($client);
     }
 
@@ -41,11 +52,13 @@ class MemcacheFactory extends AbstractAdapterFactory
     protected static function configureOptionResolver(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-          'host' => '127.0.0.1',
-          'port' => 11211,
+          'host'              => '127.0.0.1',
+          'port'              => 11211,
+          'redundant_servers' => [],
         ]);
 
         $resolver->setAllowedTypes('host', ['string']);
         $resolver->setAllowedTypes('port', ['string', 'int']);
+        $resolver->setAllowedTypes('redundant_servers', ['array']);
     }
 }

--- a/src/Factory/MemcachedFactory.php
+++ b/src/Factory/MemcachedFactory.php
@@ -33,6 +33,17 @@ class MemcachedFactory extends AbstractAdapterFactory
         $client = new Memcached($config['persistent_id']);
         $client->addServer($config['host'], $config['port']);
 
+        foreach ($config['redundant_servers'] as $server) {
+            if (!isset($server['host'])) {
+                continue;
+            }
+            $port = $config['port'];
+            if (isset($server['port'])) {
+                $port = $server['port'];
+            }
+            $client->addServer($server['host'], $port);
+        }
+
         $pool = new MemcachedCachePool($client);
 
         if (null !== $config['pool_namespace']) {
@@ -48,15 +59,17 @@ class MemcachedFactory extends AbstractAdapterFactory
     protected static function configureOptionResolver(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'persistent_id'  => null,
-            'host'           => '127.0.0.1',
-            'port'           => 11211,
-            'pool_namespace' => null,
+            'persistent_id'     => null,
+            'host'              => '127.0.0.1',
+            'port'              => 11211,
+            'pool_namespace'    => null,
+            'redundant_servers' => [],
         ]);
 
         $resolver->setAllowedTypes('persistent_id', ['string', 'null']);
         $resolver->setAllowedTypes('host', ['string']);
         $resolver->setAllowedTypes('port', ['string', 'int']);
         $resolver->setAllowedTypes('pool_namespace', ['string', 'null']);
+        $resolver->setAllowedTypes('redundant_servers', ['array']);
     }
 }


### PR DESCRIPTION
This will fix https://github.com/php-cache/issues/issues/69

Ping @panki3a, Can you test this patch?

``` yaml
cache_adapter:
  providers:
    memcached:
      factory: 'cache.factory.memcached'
      options:
        persistent_id: 'story_pool'
        host: 'foo'
        port: 123
        redundant_servers:
          - host: 'bar'
            post: 123
          - host: 'baz'
            post: 123
```
