### PR TITLE
Add support for prefixed cache

### DIFF
--- a/src/Factory/PrefixedFactory.php
+++ b/src/Factory/PrefixedFactory.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of php-cache organization.
+ *
+ * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Cache\AdapterBundle\Factory;
+
+use Cache\Prefixed\PrefixedCachePool;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class PrefixedFactory extends AbstractAdapterFactory
+{
+    protected static $dependencies = [
+        ['requiredClass' => 'Cache\Prefixed\PrefixedCachePool', 'packageName' => 'cache/prefixed-cache'],
+    ];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAdapter(array $config)
+    {
+        return new PrefixedCachePool($config['service'], $config['prefix']);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected static function configureOptionResolver(OptionsResolver $resolver)
+    {
+        parent::configureOptionResolver($resolver);
+
+        $resolver->setRequired(['prefix', 'service']);
+        $resolver->setAllowedTypes('service', ['object']);
+        $resolver->setAllowedTypes('prefix', ['string']);
+    }
+}

--- a/src/Factory/PrefixedFactory.php
+++ b/src/Factory/PrefixedFactory.php
@@ -36,7 +36,6 @@ class PrefixedFactory extends AbstractAdapterFactory
         parent::configureOptionResolver($resolver);
 
         $resolver->setRequired(['prefix', 'service']);
-        $resolver->setAllowedTypes('service', ['object']);
         $resolver->setAllowedTypes('prefix', ['string']);
     }
 }

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -15,6 +15,8 @@ services:
     class: Cache\AdapterBundle\Factory\MemcacheFactory
   cache.factory.predis:
     class: Cache\AdapterBundle\Factory\PredisFactory
+  cache.factory.prefixed:
+    class: Cache\AdapterBundle\Factory\PrefixedFactory
   cache.factory.redis:
     class: Cache\AdapterBundle\Factory\RedisFactory
   cache.factory.void:
@@ -44,4 +46,3 @@ services:
     class: Cache\AdapterBundle\Factory\DoctrineXcacheFactory
   cache.factory.doctrine_zenddata:
     class: Cache\AdapterBundle\Factory\DoctrineZendDataFactory
-


### PR DESCRIPTION
This adds support for the prefixed cache.

Example:

```
cache_adapter:
  providers:
    my_apc:
      factory: 'cache.factory.apc'
    my_prefixed:
      factory: 'cache.factory.prefixed'
      options:
        service: '@cache.provider.my_apc'
        prefix: 'some_prefix'
```