### PR TITLE
Add new default alias: "php_cache"

### DIFF
--- a/src/DependencyInjection/CacheAdapterExtension.php
+++ b/src/DependencyInjection/CacheAdapterExtension.php
@@ -61,7 +61,7 @@ class CacheAdapterExtension extends Extension
         }
 
         if ($first !== null) {
-            $container->setAlias('cache', 'cache.provider.'.$first);
+            $container->setAlias('php_cache', 'cache.provider.'.$first);
         }
     }
 

--- a/src/DependencyInjection/CacheAdapterExtension.php
+++ b/src/DependencyInjection/CacheAdapterExtension.php
@@ -61,6 +61,7 @@ class CacheAdapterExtension extends Extension
         }
 
         if ($first !== null) {
+            $container->setAlias('cache', 'cache.provider.'.$first);
             $container->setAlias('php_cache', 'cache.provider.'.$first);
         }
     }


### PR DESCRIPTION
"cache" is the name of the service for Symfony's HttpCache. We should add a additional "php_cache" alias. 