### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/tests/Unit/DsnTest.php
+++ b/tests/Unit/DsnTest.php
@@ -12,11 +12,12 @@
 namespace Cache\AdapterBundle\Tests\Unit;
 
 use Cache\AdapterBundle\DSN;
+use PHPUnit\Framework\TestCase;
 
 /**
  * DsnTest.
  */
-class DsnTest extends \PHPUnit_Framework_TestCase
+class DsnTest extends TestCase
 {
     /**
      * @static


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCase. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).