### PR TITLE
Allows passing of options to the memcached extension

### DIFF
--- a/src/Factory/MemcachedFactory.php
+++ b/src/Factory/MemcachedFactory.php
@@ -44,6 +44,10 @@ final class MemcachedFactory extends AbstractAdapterFactory
             $client->addServer($server['host'], $port);
         }
 
+        foreach ($config['driver_options'] as $constant => $value) {
+            $client->setOption(constant($constant), $value);
+        }
+
         $pool = new MemcachedCachePool($client);
 
         if (null !== $config['pool_namespace']) {
@@ -64,6 +68,7 @@ final class MemcachedFactory extends AbstractAdapterFactory
             'port'              => 11211,
             'pool_namespace'    => null,
             'redundant_servers' => [],
+            'driver_options' => [],
         ]);
 
         $resolver->setAllowedTypes('persistent_id', ['string', 'null']);
@@ -71,5 +76,6 @@ final class MemcachedFactory extends AbstractAdapterFactory
         $resolver->setAllowedTypes('port', ['string', 'int']);
         $resolver->setAllowedTypes('pool_namespace', ['string', 'null']);
         $resolver->setAllowedTypes('redundant_servers', ['array']);
+        $resolver->setAllowedTypes('driver_options', ['array']);
     }
 }


### PR DESCRIPTION
This PR allows the passing of options to the memcached extension, for example:

```
cache_adapter:
  providers:
    data:
      factory: "cache.factory.memcached"
      options:
        host: "127.0.0.1"
        port: 11211
        driver_options:
          Memcached::OPT_TCP_NODELAY: true
```
Our infrastructure doesn't like having the binary protocol enabled, we see an increase of 34ms per GET operation, but enabling TCP_NODELAY removes this while allowing us to keep the benefits of the binary protocol.

As there is no way to pass options down to the `MemcachedCachePool` we added a `driver_options` to the adapter factory so that any number of the options can be specified.