### PR TITLE
Fixed container compilation error when using Flysystem

### DIFF
--- a/src/DependencyInjection/CompilerPass/ServiceAliasCompilerPass.php
+++ b/src/DependencyInjection/CompilerPass/ServiceAliasCompilerPass.php
@@ -30,10 +30,8 @@ class ServiceAliasCompilerPass implements CompilerPassInterface
     {
         $serviceIds = array_keys($container->findTaggedServiceIds('cache.provider'));
         foreach ($serviceIds as $serviceId) {
-            $instance = $container->get($serviceId);
-            $class = get_class($instance);
-
-            $container->setAlias($class, $serviceId);
+            $definition = $container->getDefinition($serviceId);
+            $container->setAlias($definition->getClass(), $serviceId);
         }
     }
 }


### PR DESCRIPTION
Given the following (simplified) Symfony configuration:

```yaml
oneup_flysystem:
    adapters:
        vib_caching:
            local:
                directory: '%kernel.root_dir%/../var/vib-cache'
    filesystems:
        vib_caching:
            adapter: vib_caching

cache_adapter:
    providers:
        vib_caching:
            factory: 'cache.factory.filesystem'
            options:
                flysystem_service: '@oneup_flysystem.vib_caching_filesystem'
```

When you clear the cache:
```
[Symfony\Component\DependencyInjection\Exception\RuntimeException]                                                      
  Constructing service "oneup_flysystem.vib_caching_filesystem" from a parent definition is not supported at build time.
```
This is caused by the `$container->get($serviceId)` which shouldn't be done in a compiler pass.

Btw. running the tests locally gives me the following failure (which seems to be unrelated to my changes):
```
composer test                            
> vendor/bin/simple-phpunit
PHPUnit 7.4.5 by Sebastian Bergmann and contributors.

  Warning - The configuration file did not pass validation!
  The following problems have been detected:

  Line 13:
  - Element 'phpunit', attribute 'syntaxCheck': The attribute 'syntaxCheck' is not allowed.

  Test results may not be as expected.


Testing Main testsuite for AdapterBundle
.SSSPHP Fatal error:  Declaration of Matthias\SymfonyDependencyInjectionTest\PhpUnit\ContainerBuilderHasServiceDefinitionConstraint::toString() must be compatible with PHPUnit\Framework\SelfDescribing::toString(): string in /Users/richard/projects/adapter-bundle/vendor/matthiasnoback/symfony-dependency-injection-test/PhpUnit/ContainerBuilderHasServiceDefinitionConstraint.php on line 102

Fatal error: Declaration of Matthias\SymfonyDependencyInjectionTest\PhpUnit\ContainerBuilderHasServiceDefinitionConstraint::toString() must be compatible with PHPUnit\Framework\SelfDescribing::toString(): string in /Users/richard/projects/adapter-bundle/vendor/matthiasnoback/symfony-dependency-injection-test/PhpUnit/ContainerBuilderHasServiceDefinitionConstraint.php on line 102
Script vendor/bin/simple-phpunit handling the test event returned with error code 255
```